### PR TITLE
removed drop dashboards table migration file

### DIFF
--- a/db/migrate/20210824184210_drop_dashboards_table.rb
+++ b/db/migrate/20210824184210_drop_dashboards_table.rb
@@ -1,5 +1,0 @@
-class DropDashboardsTable < ActiveRecord::Migration[6.0]
-  def change
-    drop_table :dashboards
-  end
-end


### PR DESCRIPTION
Ready for review. 

Ran "rails d migration" for the migration file we want to get rid of. 