### PR TITLE
Mark tasting as finished

### DIFF
--- a/app/controllers/tastings_controller.rb
+++ b/app/controllers/tastings_controller.rb
@@ -1,11 +1,12 @@
 class TastingsController < ApplicationController
   def index
-    @tastings = policy_scope(Tasting).order(created_at: :desc)
+    @tastings = policy_scope(Tasting).order(start_at: :asc)
     if params[:query].present?
       @tastings = @tastings.search_by_params(params[:query])
     else
-      @tastings.all
+      @tastings = @tastings.all
     end
+    @tastings = @tastings.all.reject { |tasting| tasting.start_at < DateTime.now + 0.5}
   end
 
   def show

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -7,4 +7,11 @@ class Participation < ApplicationRecord
 
   validates :status, inclusion: { in: %w[pending accepted declined finished] }
   validates :initial_message, length: { maximum: 250 }
+  include ActiveModel::Validations
+  include ActiveModel::Validations::Callbacks
+  after_validation :check_status
+
+  def check_status
+    self.status = "finished" if self.tasting.start_at < DateTime.now + 0.5
+  end
 end

--- a/app/models/tasting.rb
+++ b/app/models/tasting.rb
@@ -5,7 +5,7 @@ class Tasting < ApplicationRecord
   has_many :participations, dependent: :destroy
   has_many :categorizations
   has_many :categories, through: :categorizations
-  has_one :host_participation, -> { where(host: true, status: "accepted") }, class_name: "Participation"
+  has_one :host_participation, -> { where(host: true, status: ["accepted", "finished"]) }, class_name: "Participation"
   has_one :host, through: :host_participation, source: :user
   has_one_attached :photo
 

--- a/app/views/tastings/show.html.erb
+++ b/app/views/tastings/show.html.erb
@@ -43,14 +43,26 @@
     </div>
 
     <div class="my-2">
-      <p class="mb-0"><strong> Guests: <%= @tasting.participations.accepted.count-1%>/<%= @tasting.capacity%> </strong></p>
-      <ul class="list-inline">
-        <% @tasting.participations.accepted.each do |participant| %>
-          <% unless participant.host %>
-            <li class="list-inline-item"> <%= participant.user.username %> </li>
+      <% if @tasting.host_participation.status == "finished" %>
+      <p>Tasting expired</p>
+      <p class="mb-0"><strong> Guests: <%= @tasting.participations.finished.count-1%>/<%= @tasting.capacity%> </strong></p>
+        <ul class="list-inline">
+          <% @tasting.participations.finished.each do |participant| %>
+            <% unless participant.host %>
+              <li class="list-inline-item"> <%= participant.user.username %> </li>
+            <% end %>
           <% end %>
-        <% end %>
-      </ul>
+        </ul>
+      <% else %>
+        <p class="mb-0"><strong> Guests: <%= @tasting.participations.accepted.count-1%>/<%= @tasting.capacity%> </strong></p>
+        <ul class="list-inline">
+          <% @tasting.participations.accepted.each do |participant| %>
+            <% unless participant.host %>
+              <li class="list-inline-item"> <%= participant.user.username %> </li>
+            <% end %>
+          <% end %>
+        </ul>
+      <% end %>
     </div>
     <hr>
     <div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -129,6 +129,14 @@ tastings = {
     start_at: DateTime.new(2021, 9, 11, 20, 0, 0),
     capacity: 10,
     image: 'https://res.cloudinary.com/dd3n6uf2t/image/upload/w_500,ar_16:9,c_fill,g_auto,e_sharpen/v1629996975/Tastogether/pizza_ixu3hd.jpg'
+  ),
+  barbeque: Tasting.create!(
+    title: "Barbeque Bash",
+    description: "We will barbeque up all kinds of meats.",
+    location: "464 Rue McGill, Montreal",
+    start_at: DateTime.new(2021, 8, 29, 20, 0, 0),
+    capacity: 10,
+    image: 'https://res.cloudinary.com/dd3n6uf2t/image/upload/w_500,ar_16:9,c_fill,g_auto,e_sharpen/v1629996975/Tastogether/pizza_ixu3hd.jpg'
   )
 }
 
@@ -183,6 +191,13 @@ Participation.create!(
 
 Participation.create!(
   tasting: tastings[:pizza],
+  user: users[:edgar],
+  host: true,
+  initial_message: Faker::Lorem.sentence,
+  status: "accepted"
+)
+Participation.create!(
+  tasting: tastings[:barbeque],
   user: users[:edgar],
   host: true,
   initial_message: Faker::Lorem.sentence,
@@ -257,6 +272,13 @@ Participation.create!(
 Participation.create!(
   tasting: tastings[:gelato],
   user: users[:wine],
+  host: false,
+  initial_message: Faker::Lorem.sentence,
+  status: "pending"
+)
+Participation.create!(
+  tasting: tastings[:barbeque],
+  user: users[:meg],
   host: false,
   initial_message: Faker::Lorem.sentence,
   status: "pending"


### PR DESCRIPTION
Ready for review. 

Added method that runs after validation of a participation whether the tasting that participation is tied has occurred more than 12 hours ago. If so, then mark all participations associated with that tasting as finished. I also added logic to the index page so that expired tastings are not displayed. Past tastings are also already displayed in the dashboard. I also added some code to fix a bug for what was displayed on the show page of an expired tasting. 

Let me know what you think! 