### PR TITLE
Removed other tastings link and add display for number of results

### DIFF
--- a/app/views/tastings/index.html.erb
+++ b/app/views/tastings/index.html.erb
@@ -11,6 +11,7 @@
 <div class="container">
   <%= render 'shared/search_form' %>
   <div>
+      <p><%= @tastings.count %> <%= @tastings.count != 1 ? "results" : "result" %> found</p>
       <div class="row justify-content-center">
         <% @tastings.each do |tasting| %>
           <div class="col-12 col-md-6 col-lg-4 d-flex justify-content-center">

--- a/app/views/tastings/show.html.erb
+++ b/app/views/tastings/show.html.erb
@@ -116,6 +116,5 @@
         <% end %>
       <% end %>
     </div>
-    <%= link_to "Other Tastings", tastings_path, class: "btn btn-secondary rounded my-3" %>
   </div>
 </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2021_08_31_144103) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.float "review"
     t.index ["tasting_id"], name: "index_participations_on_tasting_id"
     t.index ["user_id"], name: "index_participations_on_user_id"
   end


### PR DESCRIPTION
Ready for review.

From our discussion with Stephane earlier today, I removed the other tastings link in the tastings show page as it was redundant and added functionality to display the number of results that appear based on a search. The review column for participation was also added because in a different branch I was working on reviews. Ignore for now. 

![Screen Shot 2021-08-31 at 2 10 45 PM](https://user-images.githubusercontent.com/83660945/131554255-b01d0de4-32cf-406d-8ad4-2b2cd020d906.png)
![Screen Shot 2021-08-31 at 2 11 02 PM](https://user-images.githubusercontent.com/83660945/131554302-a358b87f-16ab-41c3-b3e3-7bde5969b40e.png)
