### PR TITLE
Fix navbar vocab and icon

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -23,8 +23,8 @@
 
     <%= link_to conversations_path, class: "nav-link my-nav-link" do %>
       <li class="nav-item my-nav-item mx-3">
-        <i class="fas fa-comments mx-auto text-body"></i>
-        <p class="mt-2">DM</p>
+        <i class="fas fa-inbox mx-auto text-body"></i>
+        <p class="mt-2">Inbox</p>
         <%= render 'shared/message_badge' %>
       </li>
     <% end %>


### PR DESCRIPTION
<img width="359" alt="Screen Shot 2021-09-01 at 9 33 51 AM" src="https://user-images.githubusercontent.com/62083493/131680733-894f3caf-bc72-4578-abef-2be179fcb8a8.png">
Fix according to Esteban's recommendation