### PR TITLE
moved the notification_channel js function outside turbolinks to fix duplicate

### DIFF
--- a/app/javascript/channels/notification_channel.js
+++ b/app/javascript/channels/notification_channel.js
@@ -9,7 +9,6 @@ const initNotificationCable = () => {
       received(data) {
         console.log(data); // called when data is broadcast in the cable
         document.body.insertAdjacentHTML("beforeend", data.template)
-        notificationBadge.innerText = data.notification_count
         notificationBadge.classList.remove('d-none')
       },
       connected(data) {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -32,5 +32,6 @@ import { initNotificationCable } from '../channels/notification_channel'
 document.addEventListener('turbolinks:load', () => {
   // Call your functions here, e.g:
   // initSelect2();
-  initNotificationCable();
 });
+
+initNotificationCable();


### PR DESCRIPTION
I have to test this on heroku. Might be a temporary fix.