### PR TITLE
Categories appear inline

### DIFF
--- a/app/views/tastings/index.html.erb
+++ b/app/views/tastings/index.html.erb
@@ -34,14 +34,14 @@
                       <%= image_tag 'https://res.cloudinary.com/dd3n6uf2t/image/upload/w_1000,c_fill,ar_1:1,g_auto,r_max,b_rgb:262c35/v1630205006/silhouette_od01kv.jpg', class: "card-product-user rounded-circle border", width: 50, height: 50 %>
                     <% end %>
                   </div>
-                    <h3 class="card-title"><%= tasting.title %></h3>
-                    <ul class="list-inline">
+                  <h3 class="card-title"><%= tasting.title %></h3>
+                  <div class="d-flex">
                       <% tasting.categories.each do |category| %>
                         <%= link_to "/tastings?query=#{category.name.downcase}&commit=Discover", query: category.name.downcase do %>
-                          <li class="list-inline-item card-text">#<%= category.name.downcase %><li>
+                          <p class="card-text">#<%= category.name.downcase %></p>
                         <% end %>
                       <% end %>
-                    </ul>
+                  </div>
                 </div>
                 <ul>
                   <li class="text-right">


### PR DESCRIPTION
Ready for review.

Made categories in index tastings page appear inline on the tasting card.
![Screen Shot 2021-09-01 at 5 22 52 PM](https://user-images.githubusercontent.com/83660945/131747041-72b51803-2fbd-4790-90b9-1c8b8f2191d2.png)
